### PR TITLE
Fix for C++11 build errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,5 +31,7 @@ fn main() {
             config.include(path);
         }
     }
-    config.build("src/lib.rs");
+    config
+    .flag("-std=c++14")
+    .build("src/lib.rs");
 }


### PR DESCRIPTION
Just a flag bumping c++ version used during build to c++14, this fixes some errors for building in systems like Arch Linux, and etc. Possible fix for #18 