### PR TITLE
fix: Enable build-native on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ build = "build.rs"
 
 include = ["src/**/*.rs", "build.rs", "Cargo.toml", "LICENSE"]
 
+[package.metadata.docs.rs]
+features = ["build-native"] # otehrwise the build will fail in docs.rs
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]


### PR DESCRIPTION
Otherwise the project will fail to build the documentation:
https://docs.rs/crate/dlib-face-recognition/0.3.0/builds/796164