### PR TITLE
fix(#18): System dlib build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlib-face-recognition"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Ashley <expenses@airmail.cc>",
     "Ho Kim <great.ho.kim@gmail.com>",

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,7 @@ fn main() {
         println!("cargo:rustc-link-lib=dlib");
         println!("cargo:rustc-link-lib=blas");
         println!("cargo:rustc-link-lib=lapack");
+        config.flag_if_supported("-std=c++14");
     } 
 
     if let Ok(paths) = std::env::var("DEP_DLIB_INCLUDE") {


### PR DESCRIPTION
It seems new versions of dlib use C++14, and require you to set `-std=c++14`, `cpp_build` defaults(?) to C++11.

This was tested using DLib 19.24.2 on NixOs, using GCC 12.3.0.